### PR TITLE
fix: create empty response when it has error in http

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@mapbox/geo-viewport": "^0.5.0",
 				"@maplibre/maplibre-gl-native": "^5.2.0",
+				"color": "^4.2.3",
 				"pmtiles": "^2.10.0",
 				"request": "^2.88.2",
 				"sharp": "^0.32.5"
@@ -18,7 +19,9 @@
 				"@maplibre/maplibre-gl-style-spec": "^19.3.2",
 				"@sveltejs/adapter-node": "^1.3.1",
 				"@sveltejs/kit": "^1.20.4",
+				"@types/color": "^3.0.4",
 				"@types/node": "^20.5.9",
+				"@types/request": "^2.48.9",
 				"@typescript-eslint/eslint-plugin": "^5.45.0",
 				"@typescript-eslint/parser": "^5.45.0",
 				"@undp-data/svelte-undp-design": "^0.3.3",
@@ -1117,6 +1120,36 @@
 				"vite": "^4.0.0"
 			}
 		},
+		"node_modules/@types/caseless": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.3.tgz",
+			"integrity": "sha512-ZD/NsIJYq/2RH+hY7lXmstfp/v9djGt9ah+xRQ3pcgR79qiKsG4pLl25AI7IcXxVO8dH9GiBE5rAknC0ePntlw==",
+			"dev": true
+		},
+		"node_modules/@types/color": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.4.tgz",
+			"integrity": "sha512-OpisS4bqJJwbkkQRrMvURf3DOxBoAg9mysHYI7WgrWpSYHqHGKYBULHdz4ih77SILcLDo/zyHGFyfIl9yb8NZQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/color-convert": "*"
+			}
+		},
+		"node_modules/@types/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-GwXanrvq/tBHJtudbl1lSy9Ybt7KS9+rA+YY3bcuIIM+d6jSHUr+5yjO83gtiRpuaPiBccwFjSnAK2qSrIPA7w==",
+			"dev": true,
+			"dependencies": {
+				"@types/color-name": "*"
+			}
+		},
+		"node_modules/@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+			"dev": true
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.2.tgz",
@@ -1176,6 +1209,32 @@
 			"integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
 			"dev": true
 		},
+		"node_modules/@types/request": {
+			"version": "2.48.9",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.9.tgz",
+			"integrity": "sha512-4mi2hYsvPAhe8RXjk5DKB09sAUzbK68T2XjORehHdWyxFoX2zUnfi1VQ5wU4Md28H/5+uB4DkxY9BS4B87N/0A==",
+			"dev": true,
+			"dependencies": {
+				"@types/caseless": "*",
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"form-data": "^2.5.0"
+			}
+		},
+		"node_modules/@types/request/node_modules/form-data": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 0.12"
+			}
+		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1196,6 +1255,12 @@
 			"dependencies": {
 				"@types/geojson": "*"
 			}
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.3.tgz",
+			"integrity": "sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg==",
+			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.62.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
 		"@maplibre/maplibre-gl-style-spec": "^19.3.2",
 		"@sveltejs/adapter-node": "^1.3.1",
 		"@sveltejs/kit": "^1.20.4",
+		"@types/color": "^3.0.4",
 		"@types/node": "^20.5.9",
+		"@types/request": "^2.48.9",
 		"@typescript-eslint/eslint-plugin": "^5.45.0",
 		"@typescript-eslint/parser": "^5.45.0",
 		"@undp-data/svelte-undp-design": "^0.3.3",
@@ -40,6 +42,7 @@
 	"dependencies": {
 		"@mapbox/geo-viewport": "^0.5.0",
 		"@maplibre/maplibre-gl-native": "^5.2.0",
+		"color": "^4.2.3",
 		"pmtiles": "^2.10.0",
 		"request": "^2.88.2",
 		"sharp": "^0.32.5"

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -5,7 +5,6 @@
 	import { Footer, Header, type HeaderLink } from '@undp-data/svelte-undp-design';
 
 	let title = $page.data.title ?? 'GeoHub Static Image API';
-	let content = $page.data.content ?? 'GeoHub Static Image API';
 	let site_name = $page.data.site_name ?? 'GeoHub Static Image API';
 	let site_description =
 		$page.data.site_description ??
@@ -13,7 +12,6 @@
 
 	afterNavigate(() => {
 		title = $page.data.title ?? 'GeoHub Static Image API';
-		content = $page.data.content ?? 'GeoHub Static Image API';
 		site_name = $page.data.site_name ?? 'GeoHub Static Image API';
 		site_description =
 			$page.data.site_description ??

--- a/src/routes/(app)/+page.ts
+++ b/src/routes/(app)/+page.ts
@@ -2,10 +2,8 @@ import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
 	const title = 'GeoHub Static Image API';
-	const content = 'GeoHub Static Image API';
 
 	return {
-		title,
-		content
+		title
 	};
 };

--- a/src/routes/(app)/playground/+page.svelte
+++ b/src/routes/(app)/playground/+page.svelte
@@ -21,11 +21,11 @@
 	let width = 300;
 	let height = 200;
 	let bbox: [number, number, number, number];
-	let latitude: number = 0;
-	let longitude: number = 0;
-	let zoom: number = 3;
-	let bearing: number = 0;
-	let pitch: number = 0;
+	let latitude = 0;
+	let longitude = 0;
+	let zoom = 3;
+	let bearing = 0;
+	let pitch = 0;
 	let isRetina = false;
 
 	let mapContainer: HTMLDivElement;

--- a/src/routes/(app)/playground/+page.ts
+++ b/src/routes/(app)/playground/+page.ts
@@ -1,12 +1,10 @@
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
-	const title = 'Playground | Static API';
-	const content = 'GeoHub Static API Playground';
+	const title = 'Playground | GeoHub Static API';
 
 	return {
-		title,
-		content
+		title
 	};
 };
 


### PR DESCRIPTION
fixes https://github.com/UNDP-Data/geohub/issues/1964

I added the following code from tileserver-gl to return empty response when it has HTTP error

https://github.com/maptiler/tileserver-gl/blob/592beaab29829a90236a9c0e8119de6c55b7b5e7/src/serve_rendered.js#L61-L99